### PR TITLE
Pin symfony sub-dependencies at ~2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require": {
     "php": ">=5.3.0",
     "composer/installers": "~1.0",
-    "drupal/drupal-driver": "*"
+    "drupal/drupal-driver": "*",
+    "symfony/dependency-injection": "~2.6"
   }
 }


### PR DESCRIPTION
Over in https://github.com/jhedstrom/drupalextension/pull/244 there is some version soup happening since the Drupal Drivers are _technically_ compatible with Symfony 2 or 3 (for instance, Symfony 3 works fine with D7). When the secondary `composer install` occurs during the Travis run, this library is pulling down Symfony 3, which then throws an error:

```
Runtime Notice: Declaration of Symfony\Component\DependencyInjection\DefinitionDecorator::setFactoryService() should be compatible with Symfony\Component\DependencyInjection\Definition::setFactoryService($factoryService, $triggerDeprecationError = true) in drupal/vendor/symfony/dependency-injection/DefinitionDecorator.php line 212
```

This PR pins anything use the endpoint to Symfony 2.x.
