### PR TITLE
Generic entity support

### DIFF
--- a/behat.d7.drush.inc
+++ b/behat.d7.drush.inc
@@ -82,7 +82,7 @@ function drush_behat_op_create_entity($settings) {
 /**
  * Delete an entity.
  */
-public function drush_behat_op_delete_entity($settings) {
+function drush_behat_op_delete_entity($settings) {
   // @todo: create a D7 version of this function
   throw new \Exception('Deletion of entities via the generic Entity API is not yet implemented for Drupal 7.');
 }

--- a/behat.d7.drush.inc
+++ b/behat.d7.drush.inc
@@ -72,6 +72,22 @@ function drush_behat($operation, $json_data) {
 }
 
 /**
+ * Create an entity.
+ */
+function drush_behat_op_create_entity($settings) {
+  // @todo: create a D7 version of this function
+  throw new \Exception('Creation of entities via the generic Entity API is not yet implemented for Drupal 7.');
+}
+
+/**
+ * Delete an entity.
+ */
+public function drush_behat_op_delete_entity($settings) {
+  // @todo: create a D7 version of this function
+  throw new \Exception('Deletion of entities via the generic Entity API is not yet implemented for Drupal 7.');
+}
+
+/**
  * Create a node.
  */
 function drush_behat_op_create_node($node) {

--- a/behat.d8.drush.inc
+++ b/behat.d8.drush.inc
@@ -95,7 +95,7 @@ function drush_behat_op_create_entity($settings) {
   }
 
   // Attempt to decipher any fields that may be specified.
-  _drush_behat_expand_entity_fields('node', $node);
+  _drush_behat_expand_entity_fields($entity_type, $entity);
   $createdEntity = entity_create($entity_type, (array) $entity);
   $createdEntity->save();
 
@@ -107,7 +107,7 @@ function drush_behat_op_create_entity($settings) {
 /**
  * Delete an entity.
  */
-public function drush_behat_op_delete_entity($settings) {
+function drush_behat_op_delete_entity($settings) {
   $entity_type = $settings['entity_type'];
   $entity = $settings['entity'];
 

--- a/behat.d8.drush.inc
+++ b/behat.d8.drush.inc
@@ -10,6 +10,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\taxonomy\TermInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 
 include __DIR__ . '/behat-drush-common.inc';
 
@@ -67,6 +68,52 @@ function drush_behat($operation, $json_data) {
   }
   else {
     return drush_set_error('DRUSH_BEHAT_NO_OPERATION', dt("Operation '!op' unknown", array('!op' => $operation)));
+  }
+}
+
+/**
+ * Create an entity.
+ */
+function drush_behat_op_create_entity($settings) {
+  $entity_type = $settings['entity_type'];
+  $entity = $settings['entity'];
+
+  // If the bundle field is empty, put the inferred bundle value in it
+  $bundle_key = \Drupal::entityManager()->getDefinition($entity_type)->getKey('bundle');
+  if (!isset($entity->$bundle_key) && isset($entity->step_bundle)) $entity->$bundle_key = $entity->step_bundle;
+
+  // Throw an exception if a bundle is specified but does not exist.
+  if (isset($entity->$bundle_key) && ($entity->$bundle_key !== NULL)) {
+    $bundles = \Drupal::entityManager()->getBundleInfo($entity_type);
+
+    if (!in_array($entity->$bundle_key, array_keys($bundles))) {
+      throw new \Exception("Cannot create entity because provided bundle '$entity->$bundle_key' does not exist.");
+    }
+  }
+  if (empty($entity_type)) {
+    throw new \Exception("You must specify an entity type to create an entity.");
+  }
+
+  // Attempt to decipher any fields that may be specified.
+  _drush_behat_expand_entity_fields('node', $node);
+  $createdEntity = entity_create($entity_type, (array) $entity);
+  $createdEntity->save();
+
+  $entity->id = $createdEntity->id();
+
+  return (array) $entity;
+}
+
+/**
+ * Delete an entity.
+ */
+public function drush_behat_op_delete_entity($settings) {
+  $entity_type = $settings['entity_type'];
+  $entity = $settings['entity'];
+
+  $entity = $entity instanceof ContentEntityInterface ? $entity : entity_load($entity_type, $entity->id);
+  if ($entity instanceof ContentEntityInterface) {
+    $entity->delete();
   }
 }
 

--- a/behat.d8.drush.inc
+++ b/behat.d8.drush.inc
@@ -75,8 +75,8 @@ function drush_behat($operation, $json_data) {
  * Create an entity.
  */
 function drush_behat_op_create_entity($settings) {
-  $entity_type = $settings['entity_type'];
-  $entity = $settings['entity'];
+  $entity_type = $settings->entity_type;
+  $entity = $settings->entity;
 
   // If the bundle field is empty, put the inferred bundle value in it
   $bundle_key = \Drupal::entityManager()->getDefinition($entity_type)->getKey('bundle');
@@ -108,8 +108,8 @@ function drush_behat_op_create_entity($settings) {
  * Delete an entity.
  */
 function drush_behat_op_delete_entity($settings) {
-  $entity_type = $settings['entity_type'];
-  $entity = $settings['entity'];
+  $entity_type = $settings->entity_type;
+  $entity = $settings->entity;
 
   $entity = $entity instanceof ContentEntityInterface ? $entity : entity_load($entity_type, $entity->id);
   if ($entity instanceof ContentEntityInterface) {


### PR DESCRIPTION
This feature adds support for create-entity and delete-entity commands.  Drupal 7 presents an exception, however Drupal 8 will create an entity from the appropriate Gherkin syntax as defined in https://github.com/jhedstrom/drupalextension/pull/300/

https://patch-diff.githubusercontent.com/raw/jhedstrom/drupalextension/pull/300.patch is required for drupal/drupal-extension to successfully use this feature with behat.

Additionally, drupal/drupal-driver should have the Drush driver extended using the PR which I created: https://github.com/jhedstrom/DrupalDriver/pull/190 