### PR TITLE
Updating documentation to help installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@ THESE INSTRUCTIONS ARE FOR:
 
 If you are using an earlier version of Drush 8, please switch to the 8.x branch.
 
-If you are managing your Drupal site with Composer, then add the Behat Drush Endpoint to your project as follows:
+If you are managing your Drupal site with Composer using [drupal/recommended-project](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies) or [Pantheon's Example](https://github.com/pantheon-systems/example-drops-8-composer), then add the Behat Drush Endpoint to your project as follows:
+
 ```bash
 composer require drush-ops/behat-drush-endpoint:^9
 ```
-If you are not using composer.json on the remote Drupal site, then copy the entire contents of this project to either **__ROOT__**/drush or **__ROOT__**/sites/all/drush, then `cd behat-drush-endpoint` and run `composer install`.
+
+Make sure you have `composer/installers` installed and have the following path in your extra configuration:
+
+```
+    "extra": {
+        "installer-paths": {
+            "drush/Commands/contrib/{$name}": ["type:drupal-drush"]
+        },
+     }
+```
+
+If you are not using composer.json on the remote Drupal site, then copy the entire contents of this project to either **__ROOT__**/drush/Commands or **__ROOT__**/sites/all/drush/Commands, then `cd behat-drush-endpoint` and run `composer install`.


### PR DESCRIPTION
I found that in my case, I was using a pre-drush 8.2.x version of drops-8-example, but we had upgraded to drush 10 in there somewhere... upgraded all the tooling, but missed the installer's configuration change. Obviously we had no other command files in there... so yeah... just making it clear.